### PR TITLE
Add required environment variable to app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,6 +7,10 @@
     "postdeploy": "bundle exec rake db:setup"
   },
   "env": {
+    "AUTHORIZEDUSERS": {
+      "description": "A comma seperated (no spaces) list of email addresses to allow access to",
+      "required": true
+    },
     "NODE_ENROLL_SECRET": {
       "description": "A shared secret key for validating osquery endpoints.",
       "generator": "secret"


### PR DESCRIPTION
Add required environment variable to app.json so the install using heroku button doesn't fail...
